### PR TITLE
clean: rename link to the 3scale-sre github org

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 The module will create a Hypershift HostedCluster in the Hub cluster using the credentials provided in the helm provider (see example below). The module expects an already set up VPC to be provided and will only create the required IAM resources, security groups and hosted zones.
 The module will also configure the following:
 
-* A Github oauth applications as Openshift's identity provider
-* A Vault approle that grants the cluster access to a specific Vault path so the user can install external-secrets-operator with the provided credentials.
+- A Github oauth applications as Openshift's identity provider
+- A Vault approle that grants the cluster access to a specific Vault path so the user can install external-secrets-operator with the provided credentials.
 
 ## Example usage
 
@@ -37,7 +37,7 @@ Then onvoke the module in `main.tf` like this:
 
 ```hcl
 module "hostedcluster" {
-  source                = "git@github.com:3scale-ops/tf-hypershift-hostedcluster?ref=tags/0.1.0"
+  source                = "git@github.com:3scale-sre/tf-hypershift-hostedcluster?ref=tags/0.1.0"
   environment           = "dev"
   project               = "example"
   cluster               = "cluster"

--- a/security_group.tf
+++ b/security_group.tf
@@ -1,5 +1,5 @@
 module "storage_sg_3scale_management_rules" {
-  source = "git@github.com:3scale-ops/tf-aws-sg-rules.git?ref=tags/0.3.0"
+  source = "git@github.com:3scale-sre/tf-aws-sg-rules.git?ref=tags/0.3.0"
   sg_id  = aws_security_group.worker.id
 }
 

--- a/vault.tf
+++ b/vault.tf
@@ -28,6 +28,6 @@ resource "vault_approle_auth_backend_role_secret_id" "this" {
 # Retrieve GitHub oauth credentials from vault
 module "github_oauth_idp" {
   count  = var.github_oauth_enabled ? 1 : 0
-  source = "git@github.com:3scale-ops/tf-vault-secret.git?ref=tags/0.1.3"
+  source = "git@github.com:3scale-sre/tf-vault-secret.git?ref=tags/0.1.3"
   path   = "kubernetes/${var.environment}-${var.project}/${var.cluster}/github-oauth-idp"
 }


### PR DESCRIPTION
### What type of PR is this?
/kind cleanup
/kind documentation

### What this PR does / why we need it:
Updates all links to point to the 3scale-sre org after the migration.

### Notes
/kind cleanup
/kind documentation
/assign
/priority important-longterm